### PR TITLE
Improve Mac build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ pip install git+https://github.com/openai/CLIP.git
 # Download CLIP model and convert to ONNX format
 python scripts/download_models.py
 
+# macOS users: install build dependencies (protoc and gRPC plugin)
+brew install protobuf grpc
+
 # Create build directory
 mkdir -p backend/build && cd backend/build
 

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -190,11 +190,18 @@ if(PROTO_FILES)
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/generated)
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/generated)
     
+    # Find the gRPC C++ plugin used by protoc
+    find_program(GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+    if(NOT GRPC_CPP_PLUGIN_EXECUTABLE)
+        message(FATAL_ERROR "grpc_cpp_plugin not found. Please install gRPC and ensure the plugin is available in your PATH.")
+    endif()
+
     # Generate gRPC code
     foreach(PROTO_FILE ${PROTO_FILES})
         get_filename_component(PROTO_NAME ${PROTO_FILE} NAME_WE)
         execute_process(
             COMMAND protoc
+                --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN_EXECUTABLE}
                 --grpc_out=${CMAKE_CURRENT_SOURCE_DIR}/src/generated
                 --cpp_out=${CMAKE_CURRENT_SOURCE_DIR}/src/generated
                 --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/protos


### PR DESCRIPTION
## Summary
- mention protobuf & gRPC brew install step in README
- check for `grpc_cpp_plugin` in CMake and fail with helpful error if missing

## Testing
- `git status --short`