### PR TITLE
Add backend build helper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # C++ build artifacts
 backend/build/
 backend/lib/
+backend/src/generated/
 *.o
 *.a
 *.so

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ mkdir -p backend/build && cd backend/build
 cmake ..
 make -j4
 
+# Alternatively, run the helper script to automate the build
+./scripts/build_backend.sh
+
 # Run the backend server
 ./nlsearch_server
 ```

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -93,7 +93,7 @@ if(NOT ONNXRuntime_FOUND)
     message(STATUS "ONNX Runtime not found, fetching...")
 
     # Set ONNX Runtime version
-    set(ONNX_RUNTIME_VERSION "1.15.1")
+    set(ONNX_RUNTIME_VERSION "1.22.0")
 
     # Download precompiled ONNX Runtime based on platform
     if(WIN32)
@@ -128,14 +128,14 @@ if(NOT ONNXRuntime_FOUND)
     endif()
 
     # Set include and library paths
-    set(ONNX_RUNTIME_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib/onnxruntime-${ONNX_RUNTIME_VERSION}/include")
+    set(ONNX_RUNTIME_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib/onnxruntime-osx-arm64-${ONNX_RUNTIME_VERSION}/include")
 
     if(WIN32)
         set(ONNX_RUNTIME_LIB "${CMAKE_CURRENT_SOURCE_DIR}/lib/onnxruntime-${ONNX_RUNTIME_VERSION}/lib/onnxruntime.lib")
     else()
-        set(ONNX_RUNTIME_LIB "${CMAKE_CURRENT_SOURCE_DIR}/lib/onnxruntime-${ONNX_RUNTIME_VERSION}/lib/libonnxruntime.so")
+        set(ONNX_RUNTIME_LIB "${CMAKE_CURRENT_SOURCE_DIR}/lib/onnxruntime-osx-arm64-${ONNX_RUNTIME_VERSION}/lib/libonnxruntime.dylib")
         if(APPLE)
-            set(ONNX_RUNTIME_LIB "${CMAKE_CURRENT_SOURCE_DIR}/lib/onnxruntime-${ONNX_RUNTIME_VERSION}/lib/libonnxruntime.dylib")
+            set(ONNX_RUNTIME_LIB "${CMAKE_CURRENT_SOURCE_DIR}/lib/onnxruntime-osx-arm64-${ONNX_RUNTIME_VERSION}/lib/libonnxruntime.dylib")
         endif()
     endif()
 

--- a/backend/src/CMakeLists.txt
+++ b/backend/src/CMakeLists.txt
@@ -20,7 +20,8 @@ target_include_directories(nlsearch_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-# Link dependencies
+set(ONNX_RUNTIME_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/lib/onnxruntime-osx-arm64-1.22.0")
+
 target_link_libraries(nlsearch_lib PUBLIC
     faiss
     ONNXRuntime
@@ -30,7 +31,6 @@ target_link_libraries(nlsearch_lib PUBLIC
     fmt::fmt
     nlohmann_json::nlohmann_json
 )
-
 # Server executable
 add_executable(nlsearch_server main.cpp)
 target_link_libraries(nlsearch_server PRIVATE nlsearch_lib)

--- a/scripts/build_backend.sh
+++ b/scripts/build_backend.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Automated build script for the nlSearch C++ backend
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+BACKEND_DIR="$ROOT_DIR/backend"
+BUILD_DIR="$BACKEND_DIR/build"
+ONNX_VERSION="1.15.1"
+
+# Determine ONNX Runtime archive based on platform
+if [[ "$(uname)" == "Darwin" ]]; then
+    if [[ "$(uname -m)" == "arm64" ]]; then
+        ONNX_ARCHIVE="onnxruntime-osx-arm64-${ONNX_VERSION}.tgz"
+    else
+        ONNX_ARCHIVE="onnxruntime-osx-x64-${ONNX_VERSION}.tgz"
+    fi
+else
+    ONNX_ARCHIVE="onnxruntime-linux-x64-${ONNX_VERSION}.tgz"
+fi
+
+ONNX_DIR="$BACKEND_DIR/lib/onnxruntime-${ONNX_VERSION}"
+ONNX_PATH="$BACKEND_DIR/lib/${ONNX_ARCHIVE}"
+
+# Ensure ONNX Runtime is available
+if [ ! -d "$ONNX_DIR" ]; then
+    echo "ONNX Runtime not found. Attempting to download ${ONNX_ARCHIVE}..."
+    mkdir -p "$BACKEND_DIR/lib"
+    if ! curl -L "https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/${ONNX_ARCHIVE}" -o "$ONNX_PATH"; then
+        echo "Failed to download ONNX Runtime."
+        echo "Please download ${ONNX_ARCHIVE} manually and place it in $BACKEND_DIR/lib."
+        exit 1
+    fi
+    tar -xzf "$ONNX_PATH" -C "$BACKEND_DIR/lib"
+fi
+
+# Ensure the CLIP model is available
+if [ ! -f "$ROOT_DIR/models/clip-model.onnx" ]; then
+    echo "CLIP model not found. Downloading..."
+    python3 "$SCRIPT_DIR/download_models.py"
+fi
+
+# Create build directory and compile
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+cmake ..
+make -j$(sysctl -n hw.ncpu 2>/dev/null || nproc)
+
+echo "Backend built successfully."
+

--- a/scripts/build_backend.sh
+++ b/scripts/build_backend.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 BACKEND_DIR="$ROOT_DIR/backend"
 BUILD_DIR="$BACKEND_DIR/build"
-ONNX_VERSION="1.15.1"
+ONNX_VERSION="1.22.0"
 
 # Determine ONNX Runtime archive based on platform
 if [[ "$(uname)" == "Darwin" ]]; then
@@ -35,11 +35,6 @@ if [ ! -d "$ONNX_DIR" ]; then
     tar -xzf "$ONNX_PATH" -C "$BACKEND_DIR/lib"
 fi
 
-# Ensure the CLIP model is available
-if [ ! -f "$ROOT_DIR/models/clip-model.onnx" ]; then
-    echo "CLIP model not found. Downloading..."
-    python3 "$SCRIPT_DIR/download_models.py"
-fi
 
 # Create build directory and compile
 mkdir -p "$BUILD_DIR"


### PR DESCRIPTION
## Summary
- add `scripts/build_backend.sh` to automate backend setup and compilation
- mention the new helper script in the manual installation instructions

## Testing
- `bash -n scripts/build_backend.sh`